### PR TITLE
Compatibility for newest version

### DIFF
--- a/ExtDriversFromLogs/App.config
+++ b/ExtDriversFromLogs/App.config
@@ -19,7 +19,7 @@
                             <colNickname>Game Nickname</colNickname>
                             <colGameID>Game ID</colGameID>
                             <groupOpen>Open log</groupOpen>
-                            <btnOpen>Form today</btnOpen>
+                            <btnOpen>From today</btnOpen>
                             <btnOpenYesterday>From yesterday</btnOpenYesterday>
                             <btnOpenAnother>Open file</btnOpenAnother>
                             <selectGame>Select game</selectGame>

--- a/ExtDriversFromLogs/App.config
+++ b/ExtDriversFromLogs/App.config
@@ -71,7 +71,7 @@
                 <value>True</value>
             </setting>
             <setting name="regPattern" serializeAs="String">
-                <value>\[(?&lt;tHours&gt;[\d{2}]+):(?&lt;tMinutes&gt;[\d{2}]+):(?&lt;tSeconds&gt;[\d{2}]+)\]\s+Spawning\s+GameTruck\s+\((?&lt;name&gt;.+)\((?&lt;gameID&gt;\d+)\)\s+-\s+TruckersMP\s+ID:(?&lt;ets2mpID&gt;\d+)(?&lt;adInfo&gt;.*)\)\s+Additional\s+data:\s+(?&lt;adData&gt;.+)[\s\S]\[00\]\s+.+\s+.\/def\/vehicle\/truck\/(?&lt;truck&gt;.+)\/data.sii.</value>
+                <value>\[(?&lt;tHours&gt;[\d{2}]+):(?&lt;tMinutes&gt;[\d{2}]+):(?&lt;tSeconds&gt;[\d{2}]+)\]\s+Spawning\s+GameTruck\s+\((?&lt;name&gt;.+)\((?&lt;gameID&gt;\d+)\)\s+-\s+(TruckersMP\s+ID:|TMPID:\s|ETS2MPId:)(?&lt;ets2mpID&gt;\d+)(?&lt;adInfo&gt;.*)\)\s+Additional\s+data:\s+(?&lt;adData&gt;.+)[\s\S]\[00\]\s+.+\s+.\/def\/vehicle\/truck\/(?&lt;truck&gt;.+)\/data.sii.</value>
             </setting>
             <setting name="gameATS" serializeAs="String">
                 <value>False</value>

--- a/ExtDriversFromLogs/Properties/AssemblyInfo.cs
+++ b/ExtDriversFromLogs/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.2.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
+[assembly: AssemblyVersion("0.2.3.0")]
+[assembly: AssemblyFileVersion("0.2.3.0")]
 [assembly: NeutralResourcesLanguageAttribute("")]

--- a/ExtDriversFromLogs/Properties/AssemblyInfo.cs
+++ b/ExtDriversFromLogs/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.1.0")]
-[assembly: AssemblyFileVersion("0.2.1.0")]
+[assembly: AssemblyVersion("0.2.2.0")]
+[assembly: AssemblyFileVersion("0.2.2.0")]
 [assembly: NeutralResourcesLanguageAttribute("")]

--- a/ExtDriversFromLogs/Properties/Settings.Designer.cs
+++ b/ExtDriversFromLogs/Properties/Settings.Designer.cs
@@ -28,7 +28,7 @@ namespace ExtDriversFromLogs.Properties {
         [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<Language name=\"English\">\r\n  <mainForm>\r" +
             "\n    <colTruck>Truck</colTruck>\r\n    <colTag>Tag</colTag>\r\n    <colNickname>Game" +
             " Nickname</colNickname>\r\n    <colGameID>Game ID</colGameID>\r\n    <groupOpen>Open" +
-            " log</groupOpen>\r\n    <btnOpen>Form today</btnOpen>\r\n    <btnOpenYesterday>From " +
+            " log</groupOpen>\r\n    <btnOpen>From today</btnOpen>\r\n    <btnOpenYesterday>From " +
             "yesterday</btnOpenYesterday>\r\n    <btnOpenAnother>Open file</btnOpenAnother>\r\n  " +
             "  <selectGame>Select game</selectGame>\r\n    <groupSearch>Search</groupSearch>\r\n " +
             "   <btnOptions>Options</btnOptions>\r\n    <btnExit>Exit</btnExit>\r\n    <menuOpenP" +
@@ -128,7 +128,7 @@ namespace ExtDriversFromLogs.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute(@"\[(?<tHours>[\d{2}]+):(?<tMinutes>[\d{2}]+):(?<tSeconds>[\d{2}]+)\]\s+Spawning\s+GameTruck\s+\((?<name>.+)\((?<gameID>\d+)\)\s+-\s+TruckersMP\s+ID:(?<ets2mpID>\d+)(?<adInfo>.*)\)\s+Additional\s+data:\s+(?<adData>.+)[\s\S]\[00\]\s+.+\s+.\/def\/vehicle\/truck\/(?<truck>.+)\/data.sii.")]
+        [global::System.Configuration.DefaultSettingValueAttribute(@"\[(?<tHours>[\d{2}]+):(?<tMinutes>[\d{2}]+):(?<tSeconds>[\d{2}]+)\]\s+Spawning\s+GameTruck\s+\((?<name>.+)\((?<gameID>\d+)\)\s+-\s+(TruckersMP\s+ID:|TMPID:\s|ETS2MPId:)(?<ets2mpID>\d+)(?<adInfo>.*)\)\s+Additional\s+data:\s+(?<adData>.+)[\s\S]\[00\]\s+.+\s+.\/def\/vehicle\/truck\/(?<truck>.+)\/data.sii.")]
         public string regPattern {
             get {
                 return ((string)(this["regPattern"]));

--- a/ExtDriversFromLogs/Properties/Settings.settings
+++ b/ExtDriversFromLogs/Properties/Settings.settings
@@ -11,7 +11,7 @@
     &lt;colNickname&gt;Game Nickname&lt;/colNickname&gt;
     &lt;colGameID&gt;Game ID&lt;/colGameID&gt;
     &lt;groupOpen&gt;Open log&lt;/groupOpen&gt;
-    &lt;btnOpen&gt;Form today&lt;/btnOpen&gt;
+    &lt;btnOpen&gt;From today&lt;/btnOpen&gt;
     &lt;btnOpenYesterday&gt;From yesterday&lt;/btnOpenYesterday&gt;
     &lt;btnOpenAnother&gt;Open file&lt;/btnOpenAnother&gt;
     &lt;selectGame&gt;Select game&lt;/selectGame&gt;

--- a/ExtDriversFromLogs/mainForm.cs
+++ b/ExtDriversFromLogs/mainForm.cs
@@ -50,6 +50,9 @@ namespace ExtDriversFromLogs
                         case "man.tgx":
                             truckName = "MAN TGX";
                             break;
+                        case "man.tgx_euro6":
+                            truckName = "MAN TGX Euro6";
+                            break;
                         case "mercedes.actros":
                             truckName = "Mercedes Actros";
                             break;
@@ -94,6 +97,9 @@ namespace ExtDriversFromLogs
                             break;
                         case "kenworth.w900":
                             truckName = "Kenworth W900";
+                            break;
+                        case "volvo.vnl":
+                            truckName = "Volvo VNL";
                             break;
                     }
                 }

--- a/ExtDriversFromLogs/mainForm.cs
+++ b/ExtDriversFromLogs/mainForm.cs
@@ -63,20 +63,29 @@ namespace ExtDriversFromLogs
                             truckName = "Renault Premium";
                             break;
                         case "scania.r":
-                            truckName = "Scania R";
+                            truckName = "Scania R 2012";
                             break;
                         case "scania.streamline":
                             truckName = "Scania StreamLine";
                             break;
+						case "scania.r_2016":
+							truckName = "Scania R";
+							break;
+						case "scania.s_2016":
+							truckName = "Scania S";
+							break;
                         case "volvo.fh16":
-                            truckName = "Volvo FH16 (2009)";
+                            truckName = "Volvo FH16 2009";
                             break;
                         case "volvo.fh16_2012":
-                            truckName = "Volvo FH16 (2012)";
+                            truckName = "Volvo FH16 2012";
                             break;
                         case "skoda.superb":
                             truckName = "Scout Super_D";
                             break;
+						case "peterbilt.389":
+							truckName = "Peterbilt 389";
+							break;
                         case "peterbilt.579":
                             truckName = "Peterbilt 579";
                             break;

--- a/lang/pol.xml
+++ b/lang/pol.xml
@@ -22,10 +22,10 @@
         <groupLanguage>Język</groupLanguage>
         <groupOptionSearch>Opcje wyszukania</groupOptionSearch>
         <chckById>Wyszukaj po ID</chckById>
-        <chckByTag>Wyszukaj po Tag</chckByTag>
-        <chckCCase>Wielkość liter</chckCCase>
+        <chckByTag>Wyszukaj po Tagu</chckByTag>
+        <chckCCase>Bierz pod uwagę wielkość liter</chckCCase>
         <btnSave>Zapisz</btnSave>
-        <groupRegLine>Główne wyrażenie</groupRegLine>
+        <groupRegLine>Linia wyrażenia regularnego</groupRegLine>
         <lblRegAttention>Nie modyfikuj o ile nie wiesz co to jest!</lblRegAttention>
         <btnRestore>Przywróć domyślne</btnRestore>
     </optionsForm>


### PR DESCRIPTION
I managed to find differences that caused #6 and fix it. I also added new Scanias.
The new regex is:
```
\[(?<tHours>[\d{2}]+):(?<tMinutes>[\d{2}]+):(?<tSeconds>[\d{2}]+)\]\s+Spawning\s+GameTruck\s+\((?<name>.+)\((?<gameID>\d+)\)\s+-\s+(TruckersMP\s+ID:|TMPID:\s|ETS2MPId:)(?<ets2mpID>\d+)(?<adInfo>.*)\)\s+Additional\s+data:\s+(?<adData>.+)[\s\S]\[00\]\s+.+\s+.\/def\/vehicle\/truck\/(?<truck>.+)\/data.sii.
```

It works as far as 16-08-2015, but in oreder to work now one must enable advanced logging in the settings, otherwise the logs looks like this:
```
[16:39:29] Spawning GameTruck (VoDviL(153) - TMPID: 946383 - Tag: ) Additional data: 
[16:39:29] Spawning GameTruck (BARACUDA78(70) - TMPID: 948896 - Tag: TURKEY) Additional data: 
[16:39:29] Spawning GameTruck (nachodash9(98) - TMPID: 961266 - Tag: ) Additional data: 
[16:39:29] Spawning GameTruck (HMD40(351) - TMPID: 580176 - Tag: ) Additional data: 
```